### PR TITLE
allow CORS for GET/OPTIONS requests

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,27 @@ const nextConfig = {
       },
     ],
   },
+  headers: async () => {
+    return [
+      {
+        source: "/api/:path*",
+        headers: [
+          {
+            key: "Access-Control-Allow-Origin",
+            value: "*",
+          },
+          {
+            key: "Access-Control-Allow-Methods",
+            value: "GET, OPTIONS",
+          },
+          {
+            key: "Access-Control-Allow-Headers",
+            value: "Content-Type, Authorization",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
allow `GET` and `OPTIONS` requests for API routes