### PR TITLE
Search by heroes and formation name

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,12 +2,12 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.22.5
+  version: 1.22.6
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:
     - id: trunk
-      ref: v1.6.2
+      ref: v1.6.3
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -4,9 +4,15 @@ import { FormEvent, useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import FormationCard from "@/components/FormationCard";
 import { Separator } from "@/components/ui/separator";
 import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+import FormationCard from "@/components/FormationCard";
 
 import { FormationData } from "@/lib/formations";
 import { type CmsData } from "@/lib/cms-types";
@@ -58,9 +64,38 @@ export default function Search({
         onSubmit={handleSearch}
         className="flex md:w-[40vw] flex-col gap-2 px-2"
       >
-        <Label htmlFor="name" className="text-2xl">
+        <Label
+          htmlFor="name"
+          className="text-2xl flex flex-row justify-between"
+        >
           Search
+          <Popover>
+            <PopoverTrigger>
+              <p className="underline">?</p>
+            </PopoverTrigger>
+            <PopoverContent>
+              <ul className="list-disc list-inside">
+                <li>You can search for formations by name.</li>
+                <li>You can also search by hero name.</li>
+                <li>
+                  You can also search for a combination of heroes using the plus
+                  sign:
+                  <pre>arden+eironn</pre>
+                </li>
+                <li>
+                  You can use combination and single hero searches in the same
+                  query:
+                  <pre>arden+eironn rowan</pre>
+                </li>
+                <li>
+                  ComingSoon™️ we will have an even more advanced searching
+                  syntax
+                </li>
+              </ul>
+            </PopoverContent>
+          </Popover>
         </Label>
+
         <Input
           id="name"
           value={search}

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -22,20 +22,35 @@ export default function Search({
   currentUserId,
 }: Props) {
   const [search, setSearch] = useState("");
-  const [results, setResults] = useState(prePopulated);
-  const [loading, setLoading] = useState(false);
+  const [results, setResults] = useState<FormationData[]>([]);
+  const [loading, setLoading] = useState(true);
 
   const handleSearch = async (e: FormEvent) => {
     e.preventDefault();
 
     setLoading(true);
 
-    const response = await fetch(`/api/search?q=${search}`);
+    const query = encodeURIComponent(search);
+    const response = await fetch(`/api/search?q=${query}`);
     const data = await response.json();
 
-    setLoading(false);
     setResults(data.formations);
   };
+
+  // this effect will populate the results with the prePopulated data
+  useEffect(() => {
+    setResults(prePopulated);
+
+    // cleanup function to ensure we don't get errors when reloading
+    return () => {
+      setResults([]);
+    };
+  }, [prePopulated]);
+
+  // when the results are set, we can stop the loading state
+  useEffect(() => {
+    setLoading(false);
+  }, [results]);
 
   return (
     <div className="flex flex-col items-center md:px-0 md:container mx-auto">

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -78,14 +78,8 @@ export default function Search({
                 <li>You can search for formations by name.</li>
                 <li>You can also search by hero name.</li>
                 <li>
-                  You can also search for a combination of heroes using the plus
-                  sign:
-                  <pre>arden+eironn</pre>
-                </li>
-                <li>
-                  You can use combination and single hero searches in the same
-                  query:
-                  <pre>arden+eironn rowan</pre>
+                  Search terms are <b>AND</b> combined <pre>arden eironn</pre>{" "}
+                  will return formations with both heroes.
                 </li>
                 <li>
                   ComingSoon™️ we will have an even more advanced searching

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -81,10 +81,6 @@ export default function Search({
                   Search terms are <b>AND</b> combined <pre>arden eironn</pre>{" "}
                   will return formations with both heroes.
                 </li>
-                <li>
-                  ComingSoon™️ we will have an even more advanced searching
-                  syntax
-                </li>
               </ul>
             </PopoverContent>
           </Popover>

--- a/lib/server/cms-data.ts
+++ b/lib/server/cms-data.ts
@@ -7,6 +7,7 @@ import type {
   GuideHomePageCmsData,
   GuidePagesCmsData,
 } from "@/lib/cms-types";
+import { type Character } from "@/lib/characters";
 
 export async function getCmsData(): Promise<CmsData> {
   const jsonData = await (
@@ -15,6 +16,17 @@ export async function getCmsData(): Promise<CmsData> {
     )
   ).json();
   return jsonData;
+}
+
+export async function heroNameToId(): Promise<Record<string, string>> {
+  const jsonData = await getCmsData();
+  const characters = jsonData["characters"];
+  return Object.fromEntries(
+    Object.entries(characters).map(([key, data]: [string, Character]) => [
+      data["name"].toLowerCase(),
+      key,
+    ]),
+  );
 }
 
 async function getGuideCmsData(): Promise<GuideCmsData> {


### PR DESCRIPTION
add support for a more search terms.

it isn't as advanced as i'd like, but i really don't want to write a fully fledged parser, so i wrote this :)

this lets people search by fragments of a formation name as well as hero names.

search terms are `AND`d for simplicity's sake at the moment.

if we find that people really want uber advanced search syntax we can always revisit.